### PR TITLE
AOT-1286 dependency updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ def jenkinsfile
 def overrides = [
     scriptVersion  : 'v7',
     iq : true,
+    iqOrganizationName : 'Team APS',
     checkstyle : false,
     openShiftBuild: false,
     disableAllReports: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ def jenkinsfile
 
 def overrides = [
     scriptVersion  : 'v7',
-    iq : false,
+    iq : true,
     checkstyle : false,
     openShiftBuild: false,
     disableAllReports: true,

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,9 @@ pluginBundle {
 }
 
 dependencies {
-    compile(gradleApi())
-    compile('com.github.zafarkhaja:java-semver:0.9.0')
-    compile('commons-io:commons-io:2.11.0')
-    testCompile group: 'org.spockframework', name: 'spock-core', version: '1.3-groovy-2.5'
-    testCompile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.5.8', ext: 'pom'
+    implementation(gradleApi())
+    implementation('com.github.zafarkhaja:java-semver:0.9.0')
+    implementation('commons-io:commons-io:2.11.0')
+    testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.0-groovy-3.0'
+    testImplementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '3.0.7', ext: 'pom'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,6 @@ pluginBundle {
   }
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile(gradleApi())
     compile('com.github.zafarkhaja:java-semver:0.9.0')

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id "groovy"
-  id "com.gradle.plugin-publish" version "0.10.1"
+  id "com.gradle.plugin-publish" version "0.15.0"
   id "java-gradle-plugin"
   id "maven-publish"
 }
@@ -32,14 +32,13 @@ pluginBundle {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
 dependencies {
     compile(gradleApi())
     compile('com.github.zafarkhaja:java-semver:0.9.0')
-    compile('commons-io:commons-io:2.5')
+    compile('commons-io:commons-io:2.11.0')
     testCompile group: 'org.spockframework', name: 'spock-core', version: '1.3-groovy-2.5'
     testCompile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.5.8', ext: 'pom'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://nexus.sits.no/repository/gradle-distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://nexus.sits.no/repository/gradle-distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://nexus.sits.no/repository/gradle-distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Oppdatering av avhengigheter, enablet iq. Se JIRA-task for detaljer.

Får tydligvis ikke testet fullstendig inntil denne er merget til master pga: "Failure Cannot publish snapshot version to gradle plugin portal"